### PR TITLE
[Makefile.inc] use the right variable for VPD output file

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -158,7 +158,7 @@ build: $(ROM_OUT)
 $(ROM_OUT): $(COREBOOT_OUT)
 	$(VPD_TOOL) -f "$<" -O -i RO_VPD -s internal_versions="`cat $(FINAL_CONFIG_OUT)`"
 	[ -z "$(VERSION)" ] || $(VPD_TOOL) -f "$<" -i RO_VPD -s firmware_version=$(VERSION)
-	$(VPD_TOOL) -f "$@" -O -i RW_VPD || true # Format RW_VPD region, if present.
+	$(VPD_TOOL) -f "$<" -O -i RW_VPD || true # Format RW_VPD region, if present.
 	cp "$<" "$@"
 	@echo '***' >&2
 	@echo '*** Build done, $@' >&2


### PR DESCRIPTION
The path of the output file when writing the RW_VPD section was
incorrect, it was using the destination, that doesn't exist yet at that
point, rather than the source file.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>